### PR TITLE
Module name: match repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ package main
 import (
     "fmt"
 
-    "github.com/stscoundrel/riimut/elderfuthark"
-    "github.com/stscoundrel/riimut/futhorc"
-    "github.com/stscoundrel/riimut/medievalfuthork"
-    "github.com/stscoundrel/riimut/youngerfuthark"
+    "github.com/stscoundrel/riimut-go/elderfuthark"
+    "github.com/stscoundrel/riimut-go/futhorc"
+    "github.com/stscoundrel/riimut-go/medievalfuthork"
+    "github.com/stscoundrel/riimut-go/youngerfuthark"
 )
 
 func main() {
@@ -57,7 +57,7 @@ package main
 import (
     "fmt",
 
-    "github.com/stscoundrel/riimut/youngerfuthark"
+    "github.com/stscoundrel/riimut-go/youngerfuthark"
 )
 
 func main() {

--- a/elderfuthark/elderfuthark.go
+++ b/elderfuthark/elderfuthark.go
@@ -1,7 +1,7 @@
 package elderfuthark
 
 import (
-	"github.com/stscoundrel/riimut/transform"
+	"github.com/stscoundrel/riimut-go/transform"
 )
 
 func LettersToRunes(content string) string {

--- a/futhorc/futhorc.go
+++ b/futhorc/futhorc.go
@@ -1,7 +1,7 @@
 package futhorc
 
 import (
-	"github.com/stscoundrel/riimut/transform"
+	"github.com/stscoundrel/riimut-go/transform"
 )
 
 func LettersToRunes(content string) string {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/stscoundrel/riimut
+module github.com/stscoundrel/riimut-go
 
 go 1.17

--- a/medievalfuthork/medievalfuthork.go
+++ b/medievalfuthork/medievalfuthork.go
@@ -1,7 +1,7 @@
 package medievalfuthork
 
 import (
-	"github.com/stscoundrel/riimut/transform"
+	"github.com/stscoundrel/riimut-go/transform"
 )
 
 func LettersToRunes(content string) string {

--- a/riimut_test.go
+++ b/riimut_test.go
@@ -3,10 +3,10 @@ package tests
 import (
 	"testing"
 
-	"github.com/stscoundrel/riimut/elderfuthark"
-	"github.com/stscoundrel/riimut/futhorc"
-	"github.com/stscoundrel/riimut/medievalfuthork"
-	"github.com/stscoundrel/riimut/youngerfuthark"
+	"github.com/stscoundrel/riimut-go/elderfuthark"
+	"github.com/stscoundrel/riimut-go/futhorc"
+	"github.com/stscoundrel/riimut-go/medievalfuthork"
+	"github.com/stscoundrel/riimut-go/youngerfuthark"
 )
 
 func TestYoungerFutharkTransformsLettersToRunes(t *testing.T) {

--- a/youngerfuthark/youngerfuthark.go
+++ b/youngerfuthark/youngerfuthark.go
@@ -1,7 +1,7 @@
 package youngerfuthark
 
 import (
-	"github.com/stscoundrel/riimut/transform"
+	"github.com/stscoundrel/riimut-go/transform"
 )
 
 func LettersToRunes(content string) string {


### PR DESCRIPTION
While "riimut" would be beter package name, Go conventions seem to want to use repository name